### PR TITLE
add metadata-based session reconciliation for automation

### DIFF
--- a/gateway/src/lib/gateway/cron.ts
+++ b/gateway/src/lib/gateway/cron.ts
@@ -17,6 +17,7 @@ import {
   enqueueDispatch,
   enqueueDispatchInSession,
   findMappedSessionId,
+  findSessionIdByMetadata,
   generateCallbackToken,
   markDispatchRunError,
   markDispatchRunSuccess,
@@ -45,6 +46,13 @@ async function runCronJob(
   const contextKey = job.sessionMode === "persistent" ? `cron:${job.id}` : undefined;
   const existingSessionId = await findMappedSessionId(db, contextKey);
   const approvalRequired = job.approvalMode === "always";
+  const metadataLookup = contextKey
+    ? {
+        sourceType: "cron",
+        sourceId: job.id,
+        contextKey,
+      }
+    : undefined;
 
   const dispatchRun = await createDispatchRun(db, {
     callbackToken: generateCallbackToken(),
@@ -102,15 +110,19 @@ async function runCronJob(
       data: { callbackUrl },
     });
 
-    const dispatchResult = existingSessionId
+    const reconciledSessionId = !existingSessionId && metadataLookup
+      ? await findSessionIdByMetadata(serverUrl, metadataLookup, ctx.scopeUserId)
+      : existingSessionId;
+
+    const dispatchResult = reconciledSessionId
       ? callbackUrl
         ? await enqueueDispatchInSession(serverUrl, {
-            sessionId: existingSessionId,
+            sessionId: reconciledSessionId,
             content: job.prompt,
             callbackUrl,
           })
         : await executeDispatchInSession(serverUrl, {
-            sessionId: existingSessionId,
+            sessionId: reconciledSessionId,
             content: job.prompt,
             callbackUrl,
           })
@@ -122,6 +134,7 @@ async function runCronJob(
               agentName: job.agentName,
               scopeUserId: ctx.scopeUserId,
               callbackUrl,
+              metadata: metadataLookup,
             },
             job.prompt,
           )
@@ -132,6 +145,7 @@ async function runCronJob(
               agentName: job.agentName,
               scopeUserId: ctx.scopeUserId,
               callbackUrl,
+              metadata: metadataLookup,
             },
             job.prompt,
           );
@@ -147,9 +161,7 @@ async function runCronJob(
         sourceType: "cron",
         sourceId: job.id,
         sessionId,
-        metadata: {
-          cronJobName: job.name,
-        },
+        metadata: metadataLookup,
       });
     }
 

--- a/gateway/src/lib/gateway/dispatch.test.ts
+++ b/gateway/src/lib/gateway/dispatch.test.ts
@@ -3,6 +3,7 @@ import {
   consumeCognitionStream,
   createCognitionSession,
   sendCognitionMessage,
+  findSessionIdByMetadata,
   enqueueDispatchInSession,
   buildDispatchCallbackUrl,
   parseCallbackOutcome,
@@ -183,5 +184,31 @@ describe("dispatch helpers", () => {
       tokenUsage: 12,
       error: undefined,
     });
+  });
+
+  it("looks up sessions by metadata filters", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ sessions: [{ id: "session-by-metadata" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const sessionId = await findSessionIdByMetadata(
+      "http://cognition",
+      {
+        sourceType: "webhook",
+        sourceId: "wh-1",
+        contextKey: "ctx-1",
+      },
+      "gateway-automation"
+    );
+
+    expect(sessionId).toBe("session-by-metadata");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("metadata.sourceType=webhook");
+    expect(url).toContain("metadata.sourceId=wh-1");
+    expect(url).toContain("metadata.contextKey=ctx-1");
+    expect(new Headers(init.headers).get("x-cognition-scope-user")).toBe("gateway-automation");
   });
 });

--- a/gateway/src/lib/gateway/dispatch.ts
+++ b/gateway/src/lib/gateway/dispatch.ts
@@ -20,6 +20,7 @@ export interface DispatchSessionRequest {
   agentName: string;
   scopeUserId?: string;
   callbackUrl?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface DispatchMessageRequest {
@@ -193,6 +194,7 @@ export async function createCognitionSession(
       title: request.title,
       agent_name: request.agentName,
       ...(request.callbackUrl ? { callback_url: request.callbackUrl } : {}),
+      ...(request.metadata ? { metadata: request.metadata } : {}),
     }),
   });
 
@@ -487,6 +489,34 @@ export function buildDispatchCallbackUrl(baseUrl: string, token: string): string
   const url = new URL("/api/internal/dispatch/callback", baseUrl);
   url.searchParams.set("token", token);
   return url.toString();
+}
+
+export async function findSessionIdByMetadata(
+  serverUrl: string,
+  metadata: Record<string, string>,
+  scopeUserId?: string,
+): Promise<string | undefined> {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(metadata)) {
+    params.set(`metadata.${key}`, value);
+  }
+
+  const response = await fetch(`${serverUrl}/sessions?${params.toString()}`, {
+    method: "GET",
+    headers: buildScopedHeaders(scopeUserId),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to look up sessions by metadata: ${response.status} ${await response.text()}`);
+  }
+
+  const payload = (await response.json()) as {
+    sessions?: Array<{ id: string }>;
+    items?: Array<{ id: string }>;
+  };
+
+  const sessions = payload.sessions ?? payload.items ?? [];
+  return sessions[0]?.id;
 }
 
 export function parseCallbackOutcome(payload: DispatchCallbackPayload): {

--- a/gateway/src/lib/gateway/webhooks.ts
+++ b/gateway/src/lib/gateway/webhooks.ts
@@ -18,6 +18,7 @@ import {
   enqueueDispatch,
   enqueueDispatchInSession,
   findContextMapping,
+  findSessionIdByMetadata,
   generateCallbackToken,
   markDispatchRunError,
   markDispatchRunSuccess,
@@ -191,6 +192,13 @@ async function processWebhookInBackground(
   let sessionId: string | undefined;
   const contextKey = webhook.sessionMode === "persistent" ? extractContextKey(body) : undefined;
   const existingMapping = await findContextMapping(db, contextKey);
+  const metadataLookup = contextKey
+    ? {
+        sourceType: "webhook",
+        sourceId: webhook.id,
+        contextKey,
+      }
+    : undefined;
 
   try {
     const callbackBaseUrl =
@@ -233,10 +241,25 @@ async function processWebhookInBackground(
     }
 
     if (!existingMapping && contextKey) {
+      const reconciledSessionId = await findSessionIdByMetadata(serverUrl, metadataLookup!, ctx.scopeUserId);
+      if (reconciledSessionId) {
+        sessionId = reconciledSessionId;
+        await reserveContextMapping(db, {
+          key: contextKey,
+          sourceType: "webhook",
+          sourceId: webhook.id,
+          sessionId,
+          metadata: metadataLookup,
+        });
+      }
+    }
+
+    if (!existingMapping && contextKey && !sessionId) {
       sessionId = await createCognitionSession(serverUrl, {
         title: `Webhook: ${webhook.name}`,
         agentName: webhook.agentName,
         scopeUserId: ctx.scopeUserId,
+        metadata: metadataLookup,
       });
 
       await reserveContextMapping(db, {
@@ -244,9 +267,7 @@ async function processWebhookInBackground(
         sourceType: "webhook",
         sourceId: webhook.id,
         sessionId,
-        metadata: {
-          webhookName: webhook.name,
-        },
+        metadata: metadataLookup,
       });
     }
 
@@ -293,9 +314,7 @@ async function processWebhookInBackground(
         sourceType: "webhook",
         sourceId: webhook.id,
         sessionId,
-        metadata: {
-          webhookName: webhook.name,
-        },
+        metadata: metadataLookup,
       });
     }
 


### PR DESCRIPTION
## Summary
- send structured session metadata when Gateway creates automation sessions
- add metadata-based session lookup so cron and webhook runs can reconcile to existing Cognition sessions beyond local mapping alone
- preserve existing context mapping behavior while strengthening recovery/reconciliation with focused tests

## Issues
- closes #17
- references #20

## Testing
- `pnpm --dir gateway test`
- `pnpm --dir gateway typecheck`
- `pnpm --dir gateway build`

## Notes
- this extends the persistence/reconciliation story without changing the current concurrency-hardening follow-up tracked in `#20`
- session metadata is now used as a recovery path when local context mapping is absent or stale