### PR TITLE
Standardize page scrolling in app shell

### DIFF
--- a/gateway/src/app/(app)/activity/page.tsx
+++ b/gateway/src/app/(app)/activity/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CheckCircleIcon, Clock3Icon, RefreshCwIcon, XCircleIcon } from "lucide-react";
@@ -83,7 +84,7 @@ export default function ActivityPage() {
   }, [fetchRuns]);
 
   return (
-    <div className="mx-auto max-w-6xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-6xl space-y-6">
       <div className="flex items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Activity Feed</h1>
@@ -216,6 +217,6 @@ export default function ActivityPage() {
           })}
         </div>
       )}
-    </div>
+    </PageContent>
   );
 }

--- a/gateway/src/app/(app)/agents/page.tsx
+++ b/gateway/src/app/(app)/agents/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -155,7 +156,7 @@ export default function AgentsPage() {
   };
 
   return (
-    <div className="mx-auto max-w-4xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-4xl space-y-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Agents</h1>
@@ -243,7 +244,7 @@ export default function AgentsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContent>
   );
 }
 

--- a/gateway/src/app/(app)/approvals/page.tsx
+++ b/gateway/src/app/(app)/approvals/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface ApprovalRun {
@@ -67,7 +68,7 @@ export default function ApprovalsPage() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-5xl space-y-6">
       <div>
         <h1 className="text-2xl font-bold">Approvals</h1>
         <p className="mt-1 text-muted-foreground">Runs waiting for Gateway approval before execution continues</p>
@@ -135,6 +136,6 @@ export default function ApprovalsPage() {
           ))}
         </div>
       )}
-    </div>
+    </PageContent>
   );
 }

--- a/gateway/src/app/(app)/config/page.tsx
+++ b/gateway/src/app/(app)/config/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   AlertDialog,
@@ -139,7 +140,7 @@ export default function ConfigPage() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-2xl space-y-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Configuration</h1>
@@ -317,6 +318,6 @@ export default function ConfigPage() {
           </div>
         </div>
       )}
-    </div>
+    </PageContent>
   );
 }

--- a/gateway/src/app/(app)/cron/page.tsx
+++ b/gateway/src/app/(app)/cron/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -147,7 +148,7 @@ export default function CronPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-4xl space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Cron Jobs</h1>
@@ -324,7 +325,7 @@ export default function CronPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContent>
   );
 }
 

--- a/gateway/src/app/(app)/integrations/page.tsx
+++ b/gateway/src/app/(app)/integrations/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -117,7 +118,7 @@ export default function IntegrationsPage() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-5xl space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Integrations</h1>
@@ -277,6 +278,6 @@ export default function IntegrationsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContent>
   );
 }

--- a/gateway/src/app/(app)/models/page.tsx
+++ b/gateway/src/app/(app)/models/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -89,7 +90,7 @@ export default function ModelsPage() {
   const hasFilters = providerFilter || toolCallOnly || search;
 
   return (
-    <div className="mx-auto max-w-5xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-5xl space-y-6">
       <div>
         <h1 className="text-2xl font-bold">Models</h1>
         <p className="text-muted-foreground mt-1">
@@ -187,7 +188,7 @@ export default function ModelsPage() {
           </div>
         </section>
       ))}
-    </div>
+    </PageContent>
   );
 }
 

--- a/gateway/src/app/(app)/providers/page.tsx
+++ b/gateway/src/app/(app)/providers/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -182,7 +183,7 @@ export default function ProvidersPage() {
   };
 
   return (
-    <div className="mx-auto max-w-4xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-4xl space-y-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Providers</h1>
@@ -274,7 +275,7 @@ export default function ProvidersPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContent>
   );
 }
 

--- a/gateway/src/app/(app)/skills/page.tsx
+++ b/gateway/src/app/(app)/skills/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -134,7 +135,7 @@ export default function SkillsPage() {
   };
 
   return (
-    <div className="mx-auto max-w-4xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-4xl space-y-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Skills</h1>
@@ -208,7 +209,7 @@ export default function SkillsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContent>
   );
 }
 

--- a/gateway/src/app/(app)/tools/page.tsx
+++ b/gateway/src/app/(app)/tools/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WrenchIcon, RefreshCwIcon, AlertTriangleIcon, CheckCircleIcon } from "lucide-react";
 import type { ToolInfo, ToolError } from "@/types/cognition";
@@ -62,7 +63,7 @@ export default function ToolsPage() {
   }, [fetchTools]);
 
   return (
-    <div className="mx-auto max-w-4xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-4xl space-y-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Tools</h1>
@@ -137,7 +138,7 @@ export default function ToolsPage() {
           ))}
         </div>
       )}
-    </div>
+    </PageContent>
   );
 }
 

--- a/gateway/src/app/(app)/webhooks/page.tsx
+++ b/gateway/src/app/(app)/webhooks/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { PageContent } from "@/components/layout/page-content";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -153,7 +154,7 @@ export default function WebhooksPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl p-6 space-y-6">
+    <PageContent contentClassName="max-w-4xl space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Webhooks</h1>
@@ -332,7 +333,7 @@ export default function WebhooksPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContent>
   );
 }
 

--- a/gateway/src/components/layout/page-content.tsx
+++ b/gateway/src/components/layout/page-content.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+interface PageContentProps {
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
+
+export function PageContent({ children, className, contentClassName }: PageContentProps) {
+  return (
+    <div className={cn("flex h-full min-h-0 flex-1 overflow-hidden", className)}>
+      <ScrollArea className="h-full w-full min-h-0 flex-1">
+        <div className={cn("mx-auto min-h-full w-full p-6", contentClassName)}>{children}</div>
+      </ScrollArea>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #35

## Summary
- add a reusable `PageContent` wrapper for top-level app pages
- move major app pages onto a consistent internal scroll container contract
- keep page width/padding standardized while preserving the app shell viewport layout

## Verification
- pnpm build
- live browser check on `activity` and `webhooks` confirmed page-level scroll containers are present and sized correctly
