### PR TITLE
Parse nested SSE usage payloads

### DIFF
--- a/gateway/src/lib/gateway/dispatch.test.ts
+++ b/gateway/src/lib/gateway/dispatch.test.ts
@@ -50,6 +50,25 @@ describe("dispatch helpers", () => {
     });
   });
 
+  it("parses usage when Cognition nests token counts under usage", async () => {
+    const response = createSseResponse([
+      'event: usage',
+      'data: {"data":{"usage":{"input_tokens":9,"output_tokens":21}}}',
+      "",
+      'event: done',
+      'data: {"assistant_data":{"content":"Nested usage answer"}}',
+      "",
+    ].join("\n"));
+
+    const result = await consumeCognitionStream(response);
+
+    expect(result).toEqual({
+      output: "Nested usage answer",
+      tokenUsage: 30,
+      doneReceived: true,
+    });
+  });
+
   it("adds scope header when creating a Cognition session", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ id: "session-1" }), {

--- a/gateway/src/lib/gateway/dispatch.ts
+++ b/gateway/src/lib/gateway/dispatch.ts
@@ -151,8 +151,16 @@ export async function consumeCognitionStream(response: Response): Promise<Dispat
             assistant_data?: { content?: string };
             input_tokens?: number;
             output_tokens?: number;
+            usage?: {
+              input_tokens?: number;
+              output_tokens?: number;
+            };
           };
           assistant_data?: { content?: string };
+          usage?: {
+            input_tokens?: number;
+            output_tokens?: number;
+          };
         };
 
         const eventName =
@@ -164,8 +172,11 @@ export async function consumeCognitionStream(response: Response): Promise<Dispat
         }
 
         if (eventName === "usage") {
+          const nestedUsage = payload.data?.usage;
+          const directUsage = payload.usage;
           tokenUsage =
-            (payload.data?.input_tokens ?? 0) + (payload.data?.output_tokens ?? 0);
+            (nestedUsage?.input_tokens ?? payload.data?.input_tokens ?? directUsage?.input_tokens ?? 0) +
+            (nestedUsage?.output_tokens ?? payload.data?.output_tokens ?? directUsage?.output_tokens ?? 0);
         }
 
         if (!output && eventName === "done" && typeof payload.assistant_data?.content === "string") {


### PR DESCRIPTION
Closes #32

## Summary
- parse nested `usage` token counts from Cognition SSE payloads
- preserve token usage when the stream emits usage in alternate shapes
- add test coverage for nested SSE usage payload parsing

## Verification
- pnpm test -- src/lib/gateway/dispatch.test.ts
