### PR TITLE
Improve shell loading and notification UX

### DIFF
--- a/gateway/src/components/layout/app-shell.tsx
+++ b/gateway/src/components/layout/app-shell.tsx
@@ -64,11 +64,24 @@ export function AppShell({ children, role }: AppShellProps) {
   const [notifications, setNotifications] = useState<WsNotification[]>([]);
   const [unread, setUnread] = useState(0);
   const [bellOpen, setBellOpen] = useState(false);
+  const [wsConnected, setWsConnected] = useState(false);
 
   useEffect(() => {
     const protocol = window.location.protocol === "https:" ? "wss" : "ws";
     const ws = new WebSocket(`${protocol}://${window.location.host}/ws`);
     wsRef.current = ws;
+
+    ws.addEventListener("open", () => {
+      setWsConnected(true);
+    });
+
+    ws.addEventListener("close", () => {
+      setWsConnected(false);
+    });
+
+    ws.addEventListener("error", () => {
+      setWsConnected(false);
+    });
 
     ws.addEventListener("message", (evt) => {
       let data: Record<string, unknown>;
@@ -185,6 +198,7 @@ export function AppShell({ children, role }: AppShellProps) {
           onNewChat={handleNewChat}
           onDeleteSession={handleDeleteSession}
           onRenameSession={handleRenameSession}
+          onRetrySessions={fetchSessions}
           isAdmin={role === "admin"}
         />
         <div className="flex flex-1 flex-col overflow-hidden">
@@ -195,6 +209,9 @@ export function AppShell({ children, role }: AppShellProps) {
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" className="relative h-8 w-8">
                   <BellIcon className="h-4 w-4" />
+                  {!wsConnected && (
+                    <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border border-background bg-muted-foreground" />
+                  )}
                   {unread > 0 && (
                     <span className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-[10px] font-bold text-destructive-foreground">
                       {unread > 9 ? "9+" : unread}

--- a/gateway/src/components/layout/sidebar.tsx
+++ b/gateway/src/components/layout/sidebar.tsx
@@ -28,6 +28,7 @@ import {
   XIcon,
   LightbulbIcon,
   PlugZapIcon,
+  RefreshCcwIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -45,6 +46,7 @@ interface SidebarProps {
   onNewChat: () => void;
   onDeleteSession: (sessionId: string) => void;
   onRenameSession: (sessionId: string, title: string) => void;
+  onRetrySessions?: () => void;
 }
 
 interface NavItem {
@@ -75,7 +77,15 @@ const ADMIN_NAV_ITEMS: NavItem[] = [
   { href: "/audit", label: "Audit Log", icon: ClipboardListIcon, adminOnly: true },
 ];
 
-export function Sidebar({ sessions, loading, isAdmin, onNewChat, onDeleteSession, onRenameSession }: SidebarProps) {
+export function Sidebar({
+  sessions,
+  loading,
+  isAdmin,
+  onNewChat,
+  onDeleteSession,
+  onRenameSession,
+  onRetrySessions,
+}: SidebarProps) {
   const pathname = usePathname();
   const { sidebarOpen, setSidebarOpen, activeSessionId } = useChatStore();
 
@@ -140,6 +150,16 @@ export function Sidebar({ sessions, loading, isAdmin, onNewChat, onDeleteSession
                   {Array.from({ length: 4 }).map((_, i) => (
                     <Skeleton key={i} className="h-8 w-full rounded" />
                   ))}
+                </div>
+              ) : sessions.length === 0 ? (
+                <div className="space-y-2 rounded-md border border-dashed px-3 py-4 text-center text-xs text-muted-foreground">
+                  <p>No chats yet.</p>
+                  {onRetrySessions && (
+                    <Button variant="ghost" size="sm" className="h-7 px-2" onClick={onRetrySessions}>
+                      <RefreshCcwIcon className="mr-1.5 h-3 w-3" />
+                      Retry
+                    </Button>
+                  )}
                 </div>
               ) : (
                 <div className="space-y-0.5 py-2">


### PR DESCRIPTION
Implements issue #38 with minimal layout changes:\n- adds sidebar empty-state and retry UX\n- preserves loading skeleton behavior\n- adds a subtle notification bell connection indicator\n\nValidation caveat: package-manager tooling was unavailable in the sandbox (pnpm/npm not found), so I could not run repo lint/build commands here.