### PR TITLE
Add notification deep links for related sessions

### DIFF
--- a/gateway/src/components/layout/app-shell.tsx
+++ b/gateway/src/components/layout/app-shell.tsx
@@ -40,13 +40,12 @@ function getNotificationHref(payload: Record<string, unknown>): string | undefin
     return `/chat/${sessionId}`;
   }
 
-  const webhookId = payload.webhookId;
-  if (typeof webhookId === "string" && webhookId.length > 0) {
+  const sourceType = payload.sourceType;
+  if (sourceType === "webhook" || payload.webhookId || payload.invocationId) {
     return "/webhooks";
   }
 
-  const cronJobId = payload.cronJobId;
-  if (typeof cronJobId === "string" && cronJobId.length > 0) {
+  if (sourceType === "cron" || payload.cronJobId) {
     return "/cron";
   }
 


### PR DESCRIPTION
## Summary\n- route notification bell items to /chat/<sessionId> when sessionId is present\n- fall back to webhook or cron management surfaces when no session is attached\n- keep bell unread/history behavior unchanged\n\n## Validation\n- not run: targeted app validation recommended after confirming notification payload coverage