### PR TITLE
Add deep links from notifications to related sessions

### DIFF
--- a/gateway/src/components/layout/app-shell.tsx
+++ b/gateway/src/components/layout/app-shell.tsx
@@ -34,23 +34,13 @@ const WS_EVENT_LABELS: Record<string, (payload: Record<string, unknown>) => stri
   "webhook.invoked": (p) => `Webhook triggered: ${String(p.path ?? p.webhookId ?? "unknown")}`,
 };
 
-function getNotificationHref(payload: Record<string, unknown>): string | undefined {
+function getNotificationHref(payload: Record<string, unknown>): string {
   const sessionId = payload.sessionId;
   if (typeof sessionId === "string" && sessionId.length > 0) {
     return `/chat/${sessionId}`;
   }
 
-  const webhookId = payload.webhookId;
-  if (typeof webhookId === "string" && webhookId.length > 0) {
-    return "/webhooks";
-  }
-
-  const cronJobId = payload.cronJobId;
-  if (typeof cronJobId === "string" && cronJobId.length > 0) {
-    return "/cron";
-  }
-
-  return undefined;
+  return "/activity";
 }
 
 export function AppShell({ children, role }: AppShellProps) {

--- a/gateway/src/components/layout/app-shell.tsx
+++ b/gateway/src/components/layout/app-shell.tsx
@@ -28,19 +28,28 @@ interface WsNotification {
   href?: string;
 }
 
+function getNotificationPayloadHref(payload: Record<string, unknown>): string | undefined {
+  const sessionId = payload.sessionId;
+  if (typeof sessionId === "string" && sessionId.length > 0) {
+    return `/chat/${sessionId}`;
+  }
+
+  const route = payload.route;
+  if (typeof route === "string" && route.length > 0) {
+    return route;
+  }
+
+  return undefined;
+}
+
 const WS_EVENT_LABELS: Record<string, (payload: Record<string, unknown>) => string> = {
   "cron.run.complete": (p) => `Cron job finished: ${String(p.jobName ?? p.jobId ?? "unknown")}`,
   "cron.run.failed": (p) => `Cron job failed: ${String(p.jobName ?? p.jobId ?? "unknown")}`,
   "webhook.invoked": (p) => `Webhook triggered: ${String(p.path ?? p.webhookId ?? "unknown")}`,
 };
 
-function getNotificationHref(payload: Record<string, unknown>): string {
-  const sessionId = payload.sessionId;
-  if (typeof sessionId === "string" && sessionId.length > 0) {
-    return `/chat/${sessionId}`;
-  }
-
-  return "/activity";
+function getNotificationHref(payload: Record<string, unknown>): string | undefined {
+  return getNotificationPayloadHref(payload);
 }
 
 export function AppShell({ children, role }: AppShellProps) {

--- a/gateway/src/lib/gateway/webhooks.ts
+++ b/gateway/src/lib/gateway/webhooks.ts
@@ -516,6 +516,14 @@ async function processWebhookInBackground(
       invocationId: dispatchRunId,
       status: "success",
       sessionId,
+      route: sessionId ? `/chat/${sessionId}` : "/activity",
+      sourceType: "webhook",
+      sourceId: webhook.id,
+      metadata: {
+        ...(metadataLookup ?? {}),
+        ...(dispatchRule ? { dispatchRuleId: dispatchRule.id } : {}),
+        contextKey: effectiveContextKey,
+      },
     });
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Add deep links for notification bell events with `sessionId` so they route to `/chat/{sessionId}`.
- Include routing metadata in webhook notification payloads so notifications without a session can fall back to `/activity`.
- Preserve unread count and recent-history behavior in the bell UI.

## Validation
- Not run in this environment (Node package manager unavailable for local lint/test execution).
